### PR TITLE
Add MoviezWap provider base URL to modflix.json

### DIFF
--- a/modflix.json
+++ b/modflix.json
@@ -142,5 +142,9 @@
   "4khdhub": {
     "name": "4khdhub",
     "url": "https://4khdhub.fans"
-  }
+  },
+  "moviezwap": {
+     "name": "moviezwap",
+     "url": "https://www.moviezwap.pink/"
+   }
 }


### PR DESCRIPTION
This pull request adds the base URL for the MoviezWap provider:

- name: moviezwap
- url: https://www.moviezwap.pink/

This will allow the main project to use the MoviezWap provider for fetching and streaming content.

