### PR TITLE
add 9xflix baseUrl to https://9xflix.yoga

### DIFF
--- a/modflix.json
+++ b/modflix.json
@@ -149,5 +149,5 @@
    },
   "9xflix": {
      "name": "9xflix",
-     "url": "https://9xflix.yoga/m/"
+     "url": "https://9xflix.yoga"
 }

--- a/modflix.json
+++ b/modflix.json
@@ -146,5 +146,8 @@
   "moviezwap": {
      "name": "moviezwap",
      "url": "https://www.moviezwap.pink/"
-   }
+   },
+  "9xflix": {
+     "name": "9xflix",
+     "url": "https://9xflix.yoga/m/"
 }


### PR DESCRIPTION
## Summary
This PR updates the 9xflix provider's baseUrl in modflix.json to point to the /m/ listing page (https://9xflix.yoga/m/). This ensures that all movie and category listings are fetched from the correct entry point.

## Motivation
The /m/ page is the main listing for movies and categories on 9xflix, making scraping and data extraction more reliable and accurate.

## Changes
- Set 9xflix baseUrl to https://9xflix.yoga/m/ in modflix.json

## Testing
- Provider tested locally and returns correct posts, search results, and metadata.
- No errors encountered in test script.
